### PR TITLE
Fix a11y issues in chatbot, landmarks, and skill contrast

### DIFF
--- a/_includes/chatbot.html
+++ b/_includes/chatbot.html
@@ -35,6 +35,7 @@
     role="dialog"
     aria-label="Chat with Boris's AI assistant"
     aria-hidden="true"
+    hidden
   >
     <!-- Panel header -->
     <div id="boris-chat-header">
@@ -569,11 +570,20 @@
   var isWaiting = false;
   var hasShownIntro = false;
 
+  var closePanelTimer = null;
+
   function openPanel() {
     isOpen = true;
-    panel.classList.add('boris-chat-open');
+    if (closePanelTimer) {
+      clearTimeout(closePanelTimer);
+      closePanelTimer = null;
+    }
+    panel.hidden = false;
     panel.setAttribute('aria-hidden', 'false');
     btn.setAttribute('aria-expanded', 'true');
+    requestAnimationFrame(function () {
+      panel.classList.add('boris-chat-open');
+    });
     if (!hasShownIntro) {
       hasShownIntro = true;
       appendMessage('assistant', 'Hey — I\'m not Boris, but I know quite a bit about him. Ask me anything.');
@@ -586,6 +596,13 @@
     panel.classList.remove('boris-chat-open');
     panel.setAttribute('aria-hidden', 'true');
     btn.setAttribute('aria-expanded', 'false');
+    if (closePanelTimer) {
+      clearTimeout(closePanelTimer);
+    }
+    closePanelTimer = setTimeout(function () {
+      panel.hidden = true;
+      closePanelTimer = null;
+    }, 250);
     btn.focus();
   }
 

--- a/_includes/styles.scss
+++ b/_includes/styles.scss
@@ -740,7 +740,7 @@ ul {
     }
     p {
       font-size: $text-small !important;
-      color: rgba($black, 0.6) !important;
+      color: rgba($black, 0.82) !important;
       line-height: 1.6 !important;
     }
   }

--- a/_layouts/default-no-amp.html
+++ b/_layouts/default-no-amp.html
@@ -2,7 +2,9 @@
 <html lang="en">
   {% include head-no-amp.html %}
   <body class="cv-viewer">
-    {{ content }}
+    <main id="main-content">
+      {{ content }}
+    </main>
     {% include footer.html %}
     {% include consent.html %}
     {% include analytics.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,9 @@
 <html ⚡ lang="en">
   {% include head.html %}
   <body class="cv-viewer">
-    {{ content }}
+    <main id="main-content">
+      {{ content }}
+    </main>
     {% include footer.html %}
     {% include consent.html %}
     {% include analytics.html %}


### PR DESCRIPTION
## Summary
- fix the hidden chatbot dialog so closed-state controls are no longer exposed as focusable content
- add a proper main landmark to both layouts
- increase skill stack paragraph contrast to meet accessibility expectations

## Notes
- chat panel now uses `hidden` while closed and restores visibility before opening animation
- no product/content changes, only targeted accessibility cleanups

## Verification
- inspected diff for the three reported issue groups
- contrast update raises the affected skill text to a substantially higher contrast ratio
- recommend a quick Lighthouse/axe pass on the PR preview before merge
